### PR TITLE
Fix #18 by renaming conversion function

### DIFF
--- a/MD5.mqh
+++ b/MD5.mqh
@@ -157,46 +157,15 @@ class MD5 {
       return(len/4);
     }
 
-    static string IntegerToString(int integer_number) {
-      string hex_string="", hex_item;
-      int output[4];
-      output[0] = integer_number & 0xff;
-      for (int k = 1; k < 4; k++) 
-      {
-        output[k] = (((integer_number >> 1) & 0x7fffffff) >> (k*8 -1)) & 0xff;
+    static string IntegerToHex(long long_number) {
+      //assert(0 > 1, "integer out of range in MD5");
+      string result;
+      int integer_number = (int) long_number;
+      for (int i = 0; i < 4; i++){
+         int byte = (integer_number >> (i*8)) & 0xff;
+         StringConcatenate(result, result, StringFormat("%02x", byte));
       }
-      for (int i = 0; i < 4; i++)
-      {
-        hex_item = Dec2Hex(output[i]);
-        hex_string = StringConcatenate(hex_string, hex_item);
-      }
-      return(hex_string);
-    }
-
-    /**
-     * Assume num is little than 256.
-     */
-    static string Dec2Hex(int num) {
-      int modnum;
-      string hex;
-      for (int i =0; i < 2; i++)
-      {
-        modnum = num % 16;
-        num = (num - modnum) / 16;
-        hex = StringConcatenate(IntToHexString(modnum), hex);
-      }
-      return (hex);
-    }
-
-    static string IntToHexString(int a) {
-      string hex = "0";
-      ushort ascii;
-      if (a < 10) {
-        ascii = '0' + a;
-      } else {
-        ascii = 'a' + a - 10;
-      }
-      return (StringSetChar(hex, 0, ascii));
+      return result;
     }
 
     static int CharToInteger(int &a[]) {

--- a/MD5.mqh
+++ b/MD5.mqh
@@ -77,12 +77,12 @@ class MD5 {
       last_char[k] = 0x80;
       last[last_index] = CharToInteger(last_char);
       if (index >= 56) {
-        MD5Transform(a, b , c, d, last);
+        MD5Transform(a, b, c, d, last);
         ArrayInitialize(last, 0);
       }
       last[14] =  len << 3;
       last[15] =  ((len >> 1) & 0x7fffffff) >> 28;
-      MD5Transform(a, b , c, d, last);
+      MD5Transform(a, b, c, d, last);
       string result;
       StringConcatenate(result, IntegerToHex(a), IntegerToHex(b), IntegerToHex(c),  IntegerToHex(d));
       return result;

--- a/MD5.mqh
+++ b/MD5.mqh
@@ -83,7 +83,9 @@ class MD5 {
       last[14] =  len << 3;
       last[15] =  ((len >> 1) & 0x7fffffff) >> 28;
       MD5Transform(a, b , c, d, last);
-      return (StringConcatenate(IntegerToString(a) , IntegerToString(b) , IntegerToString(c) ,  IntegerToString(d)));
+      string result;
+      StringConcatenate(result, IntegerToHex(a), IntegerToHex(b), IntegerToHex(c),  IntegerToHex(d));
+      return result;
     }
 
     static long F(long x, long y, long z) { 

--- a/MD5.mqh
+++ b/MD5.mqh
@@ -57,7 +57,7 @@ class MD5 {
       {
         item = StringSubstr(str, i * 64, 64);
         StringToIntegerArray(buff, item);
-        MD5Transform(a, b , c, d, buff);
+        MD5Transform(a, b, c, d, buff);
       }
       ArrayInitialize(last, 0);
       ArrayInitialize(last_char, 0);

--- a/MD5.mqh
+++ b/MD5.mqh
@@ -30,6 +30,7 @@
   @see: http://www.cnblogs.com/niniwzw/archive/2009/12/05/1617685.html
 */
 
+
 // Properties.
 #property strict
 
@@ -50,7 +51,7 @@ class MD5 {
       int count = (len - index) / 64;
 
       long a = 0x67452301, b = 0xEFCDAB89, c = 0x98BADCFE, d = 0x10325476;
-      int buff[16], last[16], i, k, last_char[4], last_index;
+      int buff[16], last[16], i, k = 0, last_char[4], last_index;
       string item;
       for (i = 0; i < count; i++)
       {

--- a/MD5.mqh
+++ b/MD5.mqh
@@ -71,7 +71,7 @@ class MD5 {
         }
         for (k = 0; k < last_num; k++)
         {
-          last_char[k] = StringGetChar(str, i * 64 + count + k); 
+          last_char[k] = StringGetCharacter(str, i * 64 + count + k); 
         }
       }
       last_char[k] = 0x80;
@@ -151,8 +151,8 @@ class MD5 {
       }
       for (i = 0, j = 0; j < len; i++, j += 4) 
       {
-        output[i] = (StringGetChar(in, j)) | ((StringGetChar(in, j+1)) << 8) 
-          | ((StringGetChar(in, j+2)) << 16) | ((StringGetChar(in, j+3)) << 24);
+        output[i] = (StringGetCharacter(in, j)) | ((StringGetCharacter(in, j+1)) << 8) 
+          | ((StringGetCharacter(in, j+2)) << 16) | ((StringGetCharacter(in, j+3)) << 24);
       }
       return(len/4);
     }


### PR DESCRIPTION
The issue was caused by one of the function clashing with another function from the standard library named IntegerToString - which converted the integer to a signed decimal representation.

The new function is named IntegerToHex, instead.

I had to change some things to get this to work in MQL5. For example, StringConcatenate changed from `out = StringConcatenate(in, in);` in MQL4 to `StringConcatenate(out, in, in);` in MQL5. Same with StringGetChar to StringGetCharacter.

I removed Dec2Hex, using `StringFormat("%02x", ...)` instead.

I used this script to test this:
```
#property copyright "Copyright 2009, MetaQuotes Software Corp."
#property link      "http://www.metaquotes.net"

#include <md5.mqh>

void OnStart() {start();}
int start()
{
   Alert("Test start:");
   Alert(MD5::MD5Sum("123")); // GitHub PR test
   Alert(MD5::MD5Sum("")); //0
   Alert(MD5::MD5Sum("0")); //1
   Alert(MD5::MD5Sum("0123456789012345678901234567890123456789012345678901234")); //55
   Alert(MD5::MD5Sum("01234567890123456789012345678901234567890123456789012345")); //56
   Alert(MD5::MD5Sum("012345678901234567890123456789012345678901234567890123456")); //57
   Alert(MD5::MD5Sum("0123456789012345678901234567890123456789012345678901234567890123"));//64
   Alert(MD5::MD5Sum("01234567890123456789012345678901234567890123456789012345678901234"));//65
   return(0);
}

/**
*result:

Test start:
202cb962ac59075b964b07152d234b70
d41d8cd98f00b204e9800998ecf8427e
cfcd208495d565ef66e7dff9f98764da
6e7a4fc92eb1c3f6e652425bcc8d44b5
8af270b2847610e742b0791b53648c09
c620bace4cde41bc45a14cfa62ee3487
7f7bfd348709deeaace19e3f535f8c54
beb9f48bc802ca5ca043bcc15e219a5a

*/
```

Let me know if I should change anything.

codemill-id-585b09735ea5950004e03342 fixes #18