### PR TITLE
Added MQL4-compatible version of `iStdDevOnArray` method

### DIFF
--- a/Indicators/Indi_Alligator.mqh
+++ b/Indicators/Indi_Alligator.mqh
@@ -25,8 +25,7 @@
 
 #ifdef __MQL5__
 // Defines macros (for MQL4 backward compability).
-//#define iAlligator4(symbol, tf, jp, js, tp, ts, lp, ls, ma_method, ap, mode, shift) \
-//        Indi_Alligator::iAlligator(symbol, tf, jp, js, tp, ts, lp, ls, ma_method, ap, mode, shift);
+#define iAlligator4 Indi_Alligator::iAlligator
 #endif
 
 #ifndef __MQLBUILD__

--- a/tests/IndicatorsTest.mq5
+++ b/tests/IndicatorsTest.mq5
@@ -25,9 +25,11 @@
  */
 
 // Defines.
-#define __debug__ // Enables debug.
+#define __debug__  // Enables debug.
 
 // Includes.
+#include "../Dict.mqh"
+#include "../DictObject.mqh"
 #include "../Indicators/Indi_AC.mqh"
 #include "../Indicators/Indi_AD.mqh"
 #include "../Indicators/Indi_ADX.mqh"
@@ -39,7 +41,6 @@
 #include "../Indicators/Indi_BearsPower.mqh"
 #include "../Indicators/Indi_BullsPower.mqh"
 #include "../Indicators/Indi_CCI.mqh"
-#include "../Indicators/Indi_Price.mqh"
 #include "../Indicators/Indi_DeMarker.mqh"
 #include "../Indicators/Indi_Demo.mqh"
 #include "../Indicators/Indi_Envelopes.mqh"
@@ -54,6 +55,7 @@
 #include "../Indicators/Indi_Momentum.mqh"
 #include "../Indicators/Indi_OBV.mqh"
 #include "../Indicators/Indi_OsMA.mqh"
+#include "../Indicators/Indi_Price.mqh"
 #include "../Indicators/Indi_RSI.mqh"
 #include "../Indicators/Indi_RVI.mqh"
 #include "../Indicators/Indi_SAR.mqh"
@@ -61,19 +63,16 @@
 #include "../Indicators/Indi_Stochastic.mqh"
 #include "../Indicators/Indi_WPR.mqh"
 #include "../Indicators/Indi_ZigZag.mqh"
-#include "../Dict.mqh"
-#include "../DictObject.mqh"
 #include "../Test.mqh"
 
 // Global variables.
 Chart *chart;
-Dict<long, Indicator*> indis;
+Dict<long, Indicator *> indis;
 Dict<long, bool> tested;
 int bar_processed;
-double test_values[] = {1.245, 1.248, 1.254, 1.264, 1.268, 1.261, 1.256, 1.250,
-                        1.242, 1.240, 1.235, 1.240, 1.234, 1.245, 1.265, 1.274,
-                        1.285, 1.295, 1.300, 1.312, 1.315, 1.320, 1.325, 1.335,
-                        1.342, 1.348, 1.352, 1.357, 1.359, 1.422, 1.430, 1.435};
+double test_values[] = {1.245, 1.248, 1.254, 1.264, 1.268, 1.261, 1.256, 1.250, 1.242, 1.240, 1.235,
+                        1.240, 1.234, 1.245, 1.265, 1.274, 1.285, 1.295, 1.300, 1.312, 1.315, 1.320,
+                        1.325, 1.335, 1.342, 1.348, 1.352, 1.357, 1.359, 1.422, 1.430, 1.435};
 
 /**
  * Implements Init event handler.
@@ -106,7 +105,7 @@ void OnTick() {
     if (indis.Size() == 0) {
       return;
     }
-    for (DictIterator<long, Indicator*> iter = indis.Begin(); iter.IsValid(); ++iter) {
+    for (DictIterator<long, Indicator *> iter = indis.Begin(); iter.IsValid(); ++iter) {
       if (tested.GetByKey(iter.Key())) {
         // Indicator is already tested, skipping.
         continue;
@@ -116,8 +115,10 @@ void OnTick() {
       _indi.OnTick();
       IndicatorDataEntry _entry = _indi.GetEntry();
       if (_indi.GetState().IsReady() && _entry.IsValid()) {
-        PrintFormat("%s%s: bar %d: %s", _indi.GetName(), _indi.GetParams().indi_data ? (" (over " + _indi.GetParams().indi_data.GetName() + ")") : "", bar_processed, _indi.ToString());
-        tested.Set(iter.Key(), true); // Mark as tested.
+        PrintFormat("%s%s: bar %d: %s", _indi.GetName(),
+                    _indi.GetParams().indi_data ? (" (over " + _indi.GetParams().indi_data.GetName() + ")") : "",
+                    bar_processed, _indi.ToString());
+        tested.Set(iter.Key(), true);  // Mark as tested.
       }
     }
   }
@@ -130,7 +131,7 @@ void OnDeinit(const int reason) {
   int num_not_tested = 0;
   for (DictIterator<long, bool> iter = tested.Begin(); iter.IsValid(); ++iter) {
     if (!iter.Value()) {
-      PrintFormat("%s: Indicator not tested: %s", __FUNCTION__, EnumToString((ENUM_INDICATOR_TYPE) iter.Key()));
+      PrintFormat("%s: Indicator not tested: %s", __FUNCTION__, EnumToString((ENUM_INDICATOR_TYPE)iter.Key()));
       ++num_not_tested;
     }
   }
@@ -140,7 +141,7 @@ void OnDeinit(const int reason) {
 
   delete chart;
 
-  for (DictIterator<long, Indicator*> iter = indis.Begin(); iter.IsValid(); ++iter) {
+  for (DictIterator<long, Indicator *> iter = indis.Begin(); iter.IsValid(); ++iter) {
     delete iter.Value();
   }
 }
@@ -149,7 +150,6 @@ void OnDeinit(const int reason) {
  * Initialize indicators.
  */
 bool InitIndicators() {
-
   /* Standard indicators */
 
   // AC.
@@ -235,12 +235,12 @@ bool InitIndicators() {
 
   // Moving Average.
   MAParams ma_params(13, 10, MODE_SMA, PRICE_OPEN);
-  Indicator* indi_ma = new Indi_MA(ma_params);
+  Indicator *indi_ma = new Indi_MA(ma_params);
   indis.Set(INDI_MA, indi_ma);
 
   // MACD.
   MACDParams macd_params(12, 26, 9, PRICE_CLOSE);
-  Indicator* macd = new Indi_MACD(macd_params);
+  Indicator *macd = new Indi_MACD(macd_params);
   indis.Set(INDI_MACD, macd);
 
   // Money Flow Index (MFI).
@@ -274,6 +274,15 @@ bool InitIndicators() {
   StdDevParams stddev_params(13, 10, MODE_SMA, PRICE_OPEN);
   indis.Set(INDI_STDDEV, new Indi_StdDev(stddev_params));
 
+  // Standard Deviation (StdDev).
+  Indicator *indi_price_for_stdev = new Indi_Price(PriceIndiParams());
+
+  StdDevParams stddev_on_price_params(13, 10, MODE_SMA, PRICE_OPEN);
+  stddev_on_price_params.SetIndicatorData(indi_price_for_stdev, true);
+  stddev_on_price_params.SetIndicatorMode(0);
+  stddev_on_price_params.SetDraw(clrBlue, 1);
+  indis.Set(INDI_STDDEV_ON_PRICE, new Indi_StdDev(stddev_on_price_params));
+
   // Stochastic Oscillator.
   StochParams stoch_params(5, 3, 3, MODE_SMMA, STO_LOWHIGH);
   indis.Set(INDI_STOCHASTIC, new Indi_Stochastic(stoch_params));
@@ -306,13 +315,13 @@ bool InitIndicators() {
 
   // Current Price.
   PriceIndiParams price_params();
-  //price_params.SetDraw(clrAzure);
-  Indicator* indi_price = new Indi_Price(price_params);
+  // price_params.SetDraw(clrAzure);
+  Indicator *indi_price = new Indi_Price(price_params);
   indis.Set(INDI_PRICE, indi_price);
 
   // Bollinger Bands over Price indicator.
   PriceIndiParams price_params_4_bands();
-  Indicator* indi_price_4_bands = new Indi_Price(price_params_4_bands);
+  Indicator *indi_price_4_bands = new Indi_Price(price_params_4_bands);
   BandsParams bands_on_price_params(20, 2, 0, PRICE_OPEN);
   bands_on_price_params.SetDraw(clrCadetBlue);
   bands_on_price_params.SetIndicatorData(indi_price_4_bands);
@@ -322,7 +331,7 @@ bool InitIndicators() {
   // NOTE: If you set ma_shift parameter for MA, then StdDev will no longer
   // match built-in StdDev indicator (as it doesn't use ma_shift for averaging).
   MAParams ma_sma_params_for_stddev(13, 0, MODE_SMA, PRICE_OPEN);
-  Indicator* indi_ma_sma_for_stddev = new Indi_MA(ma_sma_params_for_stddev);
+  Indicator *indi_ma_sma_for_stddev = new Indi_MA(ma_sma_params_for_stddev);
 
   StdDevParams stddev_params_on_ma_sma(13, 10);
   stddev_params_on_ma_sma.SetDraw(true, 1);
@@ -332,7 +341,7 @@ bool InitIndicators() {
 
   // Standard Deviation (StdDev) in SMA mode over Price.
   PriceIndiParams price_params_for_stddev_sma();
-  Indicator* indi_price_for_stddev_sma = new Indi_Price(price_params_for_stddev_sma);
+  Indicator *indi_price_for_stddev_sma = new Indi_Price(price_params_for_stddev_sma);
 
   StdDevParams stddev_sma_on_price_params(13, 10, MODE_SMA, PRICE_OPEN);
   stddev_sma_on_price_params.SetDraw(true, 1);
@@ -342,7 +351,7 @@ bool InitIndicators() {
 
   // Moving Average (MA) over Price indicator.
   PriceIndiParams price_params_4_ma();
-  Indicator* indi_price_4_ma = new Indi_Price(price_params_4_ma);
+  Indicator *indi_price_4_ma = new Indi_Price(price_params_4_ma);
   MAParams ma_on_price_params(13, 10, MODE_SMA, PRICE_OPEN);
   ma_on_price_params.SetDraw(clrYellowGreen);
   ma_on_price_params.SetIndicatorData(indi_price_4_ma);
@@ -350,29 +359,29 @@ bool InitIndicators() {
 
   // @todo Price needs to have four values (OHCL).
   ma_on_price_params.indi_mode = PRICE_OPEN;
-  Indicator* indi_ma_on_price = new Indi_MA(ma_on_price_params);
+  Indicator *indi_ma_on_price = new Indi_MA(ma_on_price_params);
   indis.Set(INDI_MA_ON_PRICE, indi_ma_on_price);
 
   // Commodity Channel Index (CCI) over Price indicator.
   PriceIndiParams price_params_4_cci();
-  Indicator* indi_price_4_cci = new Indi_Price(price_params_4_cci);
-  CCIParams cci_on_price_params(14, /*unused*/PRICE_OPEN);
+  Indicator *indi_price_4_cci = new Indi_Price(price_params_4_cci);
+  CCIParams cci_on_price_params(14, /*unused*/ PRICE_OPEN);
   cci_on_price_params.SetDraw(clrYellowGreen, 1);
   cci_on_price_params.SetIndicatorData(indi_price_4_cci);
   cci_on_price_params.SetIndicatorMode(INDI_PRICE_MODE_OPEN);
-  Indicator* indi_cci_on_price = new Indi_CCI(cci_on_price_params);
+  Indicator *indi_cci_on_price = new Indi_CCI(cci_on_price_params);
   indis.Set(INDI_CCI_ON_PRICE, indi_cci_on_price);
 
   // Envelopes over Price indicator.
   PriceIndiParams price_params_4_envelopes();
-  Indicator* indi_price_4_envelopes = new Indi_Price(price_params_4_envelopes);
+  Indicator *indi_price_4_envelopes = new Indi_Price(price_params_4_envelopes);
   EnvelopesParams env_on_price_params(13, 0, MODE_SMA, PRICE_OPEN, 2);
   env_on_price_params.SetIndicatorData(indi_price_4_envelopes);
   env_on_price_params.SetDraw(clrBrown);
   indis.Set(INDI_ENVELOPES_ON_PRICE, new Indi_Envelopes(env_on_price_params));
 
   // Momentum over Price indicator.
-  Indicator* indi_price_4_momentum = new Indi_Price();
+  Indicator *indi_price_4_momentum = new Indi_Price();
   MomentumParams mom_on_price_params(12, PRICE_OPEN, 5);
   mom_on_price_params.SetIndicatorData(indi_price_4_momentum);
   mom_on_price_params.SetDraw(clrDarkCyan);
@@ -380,16 +389,15 @@ bool InitIndicators() {
 
   // Relative Strength Index (RSI) over Price indicator.
   PriceIndiParams price_params_4_rsi();
-  Indicator* indi_price_4_rsi = new Indi_Price(price_params_4_rsi);
-  RSIParams rsi_on_price_params(14, /*unused*/PRICE_OPEN);
+  Indicator *indi_price_4_rsi = new Indi_Price(price_params_4_rsi);
+  RSIParams rsi_on_price_params(14, /*unused*/ PRICE_OPEN);
   rsi_on_price_params.SetIndicatorData(indi_price_4_rsi);
   rsi_on_price_params.SetIndicatorMode(INDI_PRICE_MODE_OPEN);
   rsi_on_price_params.SetDraw(clrBisque, 1);
   indis.Set(INDI_RSI_ON_PRICE, new Indi_RSI(rsi_on_price_params));
 
   // Mark all as untested.
-  for (DictIterator<long, Indicator*> iter = indis.Begin(); iter.IsValid(); ++iter) {
-   if (iter.Key() != INDI_RSI && iter.Key() != INDI_RSI_ON_PRICE)
+  for (DictIterator<long, Indicator *> iter = indis.Begin(); iter.IsValid(); ++iter) {
     tested.Set(iter.Key(), false);
   }
 
@@ -400,10 +408,11 @@ bool InitIndicators() {
  * Print indicators.
  */
 bool PrintIndicators(string _prefix = "") {
-  for (DictIterator<long, Indicator*> iter = indis.Begin(); iter.IsValid(); ++iter) {
+  for (DictIterator<long, Indicator *> iter = indis.Begin(); iter.IsValid(); ++iter) {
     Indicator *_indi = iter.Value();
     MqlParam _value = _indi.GetEntryValue();
-    if (GetLastError() == ERR_INDICATOR_DATA_NOT_FOUND || GetLastError() == ERR_USER_ERROR_FIRST + ERR_USER_INVALID_BUFF_NUM) {
+    if (GetLastError() == ERR_INDICATOR_DATA_NOT_FOUND ||
+        GetLastError() == ERR_USER_ERROR_FIRST + ERR_USER_INVALID_BUFF_NUM) {
       ResetLastError();
       continue;
     }
@@ -472,18 +481,9 @@ bool TestAC() {
   Indi_AC *ac = new Indi_AC(params);
   IndicatorDataEntry _entry = ac.GetEntry();
   Print("AC: ", _entry.value.ToString(params.idvtype));
-  assertTrueOrReturn(
-    ac.GetValue() == ac_value,
-    "AC value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype) == ac_value,
-    "AC entry value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype) > 0,
-    "AC value is zero or negative!",
-    false);
+  assertTrueOrReturn(ac.GetValue() == ac_value, "AC value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype) == ac_value, "AC entry value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype) > 0, "AC value is zero or negative!", false);
   // Clean up.
   delete ac;
   return true;
@@ -500,18 +500,9 @@ bool TestAD() {
   Indi_AD *ad = new Indi_AD(params);
   IndicatorDataEntry _entry = ad.GetEntry();
   Print("AD: ", _entry.value.ToString(params.idvtype));
-  assertTrueOrReturn(
-    ad.GetValue() == ad_value,
-    "AD value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype) == ad_value,
-    "AD entry value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype) > 0,
-    "AD value is zero or negative!",
-    false);
+  assertTrueOrReturn(ad.GetValue() == ad_value, "AD value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype) == ad_value, "AD entry value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype) > 0, "AD value is zero or negative!", false);
   // Clean up.
   delete ad;
   return true;
@@ -527,11 +518,8 @@ bool TestADX() {
   ADXParams params(14, PRICE_HIGH);
   Indi_ADX *adx = new Indi_ADX(params);
   Print("ADX: ", adx.GetValue());
-  assertTrueOrReturn(
-    adx.GetValue() == adx_value,
-    "ADX value does not match!",
-    false);
-  adx.SetPeriod(adx.GetPeriod()+1);
+  assertTrueOrReturn(adx.GetValue() == adx_value, "ADX value does not match!", false);
+  adx.SetPeriod(adx.GetPeriod() + 1);
   // Clean up.
   delete adx;
   return true;
@@ -547,10 +535,7 @@ bool TestAO() {
   AOParams params(PERIOD_CURRENT);
   Indi_AO *ao = new Indi_AO(params);
   Print("AO: ", ao.GetValue());
-  assertTrueOrReturn(
-    ao.GetValue() == ao_value,
-    "AO value does not match!",
-    false);
+  assertTrueOrReturn(ao.GetValue() == ao_value, "AO value does not match!", false);
   // Clean up.
   delete ao;
   return true;
@@ -566,11 +551,8 @@ bool TestATR() {
   ATRParams params(14);
   Indi_ATR *atr = new Indi_ATR(params);
   Print("ATR: ", atr.GetValue());
-  assertTrueOrReturn(
-    atr.GetValue() == atr_value,
-    "ATR value does not match!",
-    false);
-  atr.SetPeriod(atr.GetPeriod()+1);
+  assertTrueOrReturn(atr.GetValue() == atr_value, "ATR value does not match!", false);
+  atr.SetPeriod(atr.GetPeriod() + 1);
   // Clean up.
   delete atr;
   return true;
@@ -581,29 +563,24 @@ bool TestATR() {
  */
 bool TestAlligator() {
   // Get static value.
-  double alligator_value = Indi_Alligator::iAlligator(_Symbol, PERIOD_CURRENT, 13, 8, 8, 5, 5, 3, MODE_SMMA, PRICE_MEDIAN, LINE_JAW);
+  double alligator_value =
+      Indi_Alligator::iAlligator(_Symbol, PERIOD_CURRENT, 13, 8, 8, 5, 5, 3, MODE_SMMA, PRICE_MEDIAN, LINE_JAW);
   // Get dynamic values.
   AlligatorParams params(13, 8, 8, 5, 5, 3, MODE_SMMA, PRICE_MEDIAN);
   Indi_Alligator *alligator = new Indi_Alligator(params);
-  PrintFormat("Alligator: %g/%g/%g", alligator.GetValue(LINE_JAW), alligator.GetValue(LINE_TEETH), alligator.GetValue(LINE_LIPS));
-  assertTrueOrReturn(
-    alligator.GetValue(LINE_JAW) == alligator_value,
-    "Alligator jaw value does not match!",
-    false);
-  assertTrueOrReturn(
-    alligator.GetValue(LINE_JAW) != alligator.GetValue(LINE_TEETH),
-    "Alligator jaw value should be different than teeth value!",
-    false);
-  assertTrueOrReturn(
-    alligator.GetValue(LINE_TEETH) != alligator.GetValue(LINE_LIPS),
-    "Alligator teeth value should be different than lips value!",
-    false);
-  alligator.SetJawPeriod(alligator.GetJawPeriod()+1);
-  alligator.SetJawShift(alligator.GetJawShift()+1);
-  alligator.SetTeethPeriod(alligator.GetTeethPeriod()+1);
-  alligator.SetTeethShift(alligator.GetTeethShift()+1);
-  alligator.SetLipsPeriod(alligator.GetLipsPeriod()+1);
-  alligator.SetLipsShift(alligator.GetLipsShift()+1);
+  PrintFormat("Alligator: %g/%g/%g", alligator.GetValue(LINE_JAW), alligator.GetValue(LINE_TEETH),
+              alligator.GetValue(LINE_LIPS));
+  assertTrueOrReturn(alligator.GetValue(LINE_JAW) == alligator_value, "Alligator jaw value does not match!", false);
+  assertTrueOrReturn(alligator.GetValue(LINE_JAW) != alligator.GetValue(LINE_TEETH),
+                     "Alligator jaw value should be different than teeth value!", false);
+  assertTrueOrReturn(alligator.GetValue(LINE_TEETH) != alligator.GetValue(LINE_LIPS),
+                     "Alligator teeth value should be different than lips value!", false);
+  alligator.SetJawPeriod(alligator.GetJawPeriod() + 1);
+  alligator.SetJawShift(alligator.GetJawShift() + 1);
+  alligator.SetTeethPeriod(alligator.GetTeethPeriod() + 1);
+  alligator.SetTeethShift(alligator.GetTeethShift() + 1);
+  alligator.SetLipsPeriod(alligator.GetLipsPeriod() + 1);
+  alligator.SetLipsShift(alligator.GetLipsShift() + 1);
   // Clean up.
   delete alligator;
   return true;
@@ -619,10 +596,7 @@ bool TestBWMFI() {
   BWMFIParams params(PERIOD_CURRENT);
   Indi_BWMFI *bwmfi = new Indi_BWMFI(params);
   Print("BWMFI: ", bwmfi.GetValue());
-  assertTrueOrReturn(
-    bwmfi.GetValue() == bwmfi_value,
-    "BWMFI value does not match!",
-    false);
+  assertTrueOrReturn(bwmfi.GetValue() == bwmfi_value, "BWMFI value does not match!", false);
   // Clean up.
   delete bwmfi;
   return true;
@@ -639,32 +613,22 @@ bool TestBands() {
   Indi_Bands *bands = new Indi_Bands(params);
   IndicatorDataEntry _entry = bands.GetEntry();
   Print("Bands: ", _entry.value.ToString(params.idvtype));
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype, BAND_BASE) == bands_value, "Bands value does not match!",
+                     false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype, BAND_BASE) == bands.GetValue(BAND_BASE),
+                     "Bands BAND_BASE value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype, BAND_LOWER) == bands.GetValue(BAND_LOWER),
+                     "Bands BAND_LOWER value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype, BAND_UPPER) == bands.GetValue(BAND_UPPER),
+                     "Bands BAND_UPPER value does not match!", false);
   assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, BAND_BASE) == bands_value,
-    "Bands value does not match!",
-    false);
+      _entry.value.GetValueDbl(params.idvtype, BAND_LOWER) < _entry.value.GetValueDbl(params.idvtype, BAND_UPPER),
+      "Bands lower value should be less than upper value!", false);
   assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, BAND_BASE) == bands.GetValue(BAND_BASE),
-    "Bands BAND_BASE value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, BAND_LOWER) == bands.GetValue(BAND_LOWER),
-    "Bands BAND_LOWER value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, BAND_UPPER) == bands.GetValue(BAND_UPPER),
-    "Bands BAND_UPPER value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, BAND_LOWER) < _entry.value.GetValueDbl(params.idvtype, BAND_UPPER),
-    "Bands lower value should be less than upper value!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, BAND_UPPER) > _entry.value.GetValueDbl(params.idvtype, BAND_BASE),
-    "Bands upper value should be greater than base value!",
-    false);
-  bands.SetPeriod(bands.GetPeriod()+1);
-  bands.SetDeviation(bands.GetDeviation()+0.1);
+      _entry.value.GetValueDbl(params.idvtype, BAND_UPPER) > _entry.value.GetValueDbl(params.idvtype, BAND_BASE),
+      "Bands upper value should be greater than base value!", false);
+  bands.SetPeriod(bands.GetPeriod() + 1);
+  bands.SetDeviation(bands.GetDeviation() + 0.1);
   // Clean up.
   delete bands;
   return true;
@@ -680,11 +644,8 @@ bool TestBearsPower() {
   BearsPowerParams params(13, PRICE_CLOSE);
   Indi_BearsPower *bp = new Indi_BearsPower(params);
   Print("BearsPower: ", bp.GetValue());
-  assertTrueOrReturn(
-    bp.GetValue() == bp_value,
-    "BearsPower value does not match!",
-    false);
-  bp.SetPeriod(bp.GetPeriod()+1);
+  assertTrueOrReturn(bp.GetValue() == bp_value, "BearsPower value does not match!", false);
+  bp.SetPeriod(bp.GetPeriod() + 1);
   bp.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
   delete bp;
@@ -701,11 +662,8 @@ bool TestBullsPower() {
   BullsPowerParams params(13, PRICE_CLOSE);
   Indi_BullsPower *bp = new Indi_BullsPower(params);
   Print("BullsPower: ", bp.GetValue());
-  assertTrueOrReturn(
-    bp.GetValue() == bp_value,
-    "BullsPower value does not match!",
-    false);
-  bp.SetPeriod(bp.GetPeriod()+1);
+  assertTrueOrReturn(bp.GetValue() == bp_value, "BullsPower value does not match!", false);
+  bp.SetPeriod(bp.GetPeriod() + 1);
   bp.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
   delete bp;
@@ -722,27 +680,21 @@ bool TestCCI() {
   CCIParams params(14, PRICE_CLOSE);
   Indi_CCI *cci = new Indi_CCI(params);
   Print("CCI: ", cci.GetValue());
-  assertTrueOrReturn(
-    cci.GetValue() == cci_value,
-    "CCI value does not match!",
-    false);
-  cci.SetPeriod(cci.GetPeriod()+1);
+  assertTrueOrReturn(cci.GetValue() == cci_value, "CCI value does not match!", false);
+  cci.SetPeriod(cci.GetPeriod() + 1);
   // Clean up.
   delete cci;
 
   double cci_on_array_1 = Indi_CCI::iCCIOnArray(test_values, 0, 13, 2);
 
-  assertTrueOrReturn(
-    cci_on_array_1 >= 233.5937 && cci_on_array_1 < 233.5938,
-    "Wrong result of iCCIOnArray. Expected ~233.5937!",
-    false);
+  assertTrueOrReturn(cci_on_array_1 >= 233.5937 && cci_on_array_1 < 233.5938,
+                     "Wrong result of iCCIOnArray. Expected ~233.5937!", false);
 
   double cci_on_array_2 = Indi_CCI::iCCIOnArray(test_values, 0, 13, 0);
 
-  assertTrueOrReturn(
-    cci_on_array_2 >= 155.7825 && cci_on_array_2 < 155.7826,
-    "Wrong result of iCCIOnArray. Expected ~155.7825, got " + DoubleToString(cci_on_array_2) + "!",
-    false);
+  assertTrueOrReturn(cci_on_array_2 >= 155.7825 && cci_on_array_2 < 155.7826,
+                     "Wrong result of iCCIOnArray. Expected ~155.7825, got " + DoubleToString(cci_on_array_2) + "!",
+                     false);
 
   return true;
 }
@@ -757,11 +709,8 @@ bool TestDeMarker() {
   DeMarkerParams params(14);
   Indi_DeMarker *dm = new Indi_DeMarker(params);
   Print("DeMarker: ", dm.GetValue());
-  assertTrueOrReturn(
-    dm.GetValue() == dm_value,
-    "DeMarker value does not match!",
-    false);
-  dm.SetPeriod(dm.GetPeriod()+1);
+  assertTrueOrReturn(dm.GetValue() == dm_value, "DeMarker value does not match!", false);
+  dm.SetPeriod(dm.GetPeriod() + 1);
   // Clean up.
   delete dm;
   return true;
@@ -778,18 +727,9 @@ bool TestDemo() {
   Indi_Demo *demo = new Indi_Demo(params);
   IndicatorDataEntry _entry = demo.GetEntry();
   Print("Demo: ", _entry.value.ToString(params.idvtype));
-  assertTrueOrReturn(
-    demo.GetValue() == demo_value,
-    "Demo value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype) == demo_value,
-    "Demo entry value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype) <= 0,
-    "Demo value is zero or negative!",
-    false);
+  assertTrueOrReturn(demo.GetValue() == demo_value, "Demo value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype) == demo_value, "Demo entry value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype) <= 0, "Demo value is zero or negative!", false);
   // Clean up.
   delete demo;
   return true;
@@ -806,28 +746,21 @@ bool TestEnvelopes() {
   Indi_Envelopes *env = new Indi_Envelopes(params);
   IndicatorDataEntry _entry = env.GetEntry();
   Print("Envelopes: ", _entry.value.ToString(params.idvtype));
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, LINE_UPPER) == env_value,
-    "Envelopes value does not match!",
-    false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype, LINE_UPPER) == env_value,
+                     "Envelopes value does not match!", false);
 
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype, LINE_LOWER) == env.GetValue(LINE_LOWER),
+                     "Envelopes LINE_LOWER value does not match!", false);
+  assertTrueOrReturn(_entry.value.GetValueDbl(params.idvtype, LINE_UPPER) == env.GetValue(LINE_UPPER),
+                     "Envelopes LINE_UPPER value does not match!", false);
   assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, LINE_LOWER) == env.GetValue(LINE_LOWER),
-    "Envelopes LINE_LOWER value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, LINE_UPPER) == env.GetValue(LINE_UPPER),
-    "Envelopes LINE_UPPER value does not match!",
-    false);
-  assertTrueOrReturn(
-    _entry.value.GetValueDbl(params.idvtype, LINE_LOWER) < _entry.value.GetValueDbl(params.idvtype, LINE_UPPER),
-    "Envelopes lower value should be less than upper value!",
-    false);
-  env.SetMAPeriod(env.GetMAPeriod()+1);
+      _entry.value.GetValueDbl(params.idvtype, LINE_LOWER) < _entry.value.GetValueDbl(params.idvtype, LINE_UPPER),
+      "Envelopes lower value should be less than upper value!", false);
+  env.SetMAPeriod(env.GetMAPeriod() + 1);
   env.SetMAMethod(MODE_SMA);
-  env.SetMAShift(env.GetMAShift()+1);
+  env.SetMAShift(env.GetMAShift() + 1);
   env.SetAppliedPrice(PRICE_MEDIAN);
-  env.SetDeviation(env.GetDeviation()+0.1);
+  env.SetDeviation(env.GetDeviation() + 0.1);
   // Clean up.
   delete env;
   return true;
@@ -843,11 +776,8 @@ bool TestForce() {
   ForceParams params(13, MODE_SMA, PRICE_CLOSE);
   Indi_Force *force = new Indi_Force(params);
   Print("Force: ", force.GetValue());
-  assertTrueOrReturn(
-    force.GetValue() == force_value,
-    "Force value does not match!",
-    false);
-  force.SetPeriod(force.GetPeriod()+1);
+  assertTrueOrReturn(force.GetValue() == force_value, "Force value does not match!", false);
+  force.SetPeriod(force.GetPeriod() + 1);
   force.SetMAMethod(MODE_SMA);
   force.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
@@ -860,19 +790,12 @@ bool TestForce() {
  */
 bool TestFractals() {
   // Get static value.
-  double fractals_value = Indi_Fractals::iFractals(
-    _Symbol,
-    PERIOD_CURRENT,
-    LINE_UPPER
-    );
+  double fractals_value = Indi_Fractals::iFractals(_Symbol, PERIOD_CURRENT, LINE_UPPER);
   // Get dynamic values.
   FractalsParams params(PERIOD_CURRENT);
   Indi_Fractals *fractals = new Indi_Fractals(params);
   Print("Fractals: ", fractals.GetValue(LINE_UPPER));
-  assertTrueOrReturn(
-    fractals.GetValue(LINE_UPPER) == fractals_value,
-    "Fractals value does not match!",
-    false);
+  assertTrueOrReturn(fractals.GetValue(LINE_UPPER) == fractals_value, "Fractals value does not match!", false);
   // Clean up.
   delete fractals;
   return true;
@@ -883,21 +806,19 @@ bool TestFractals() {
  */
 bool TestGator() {
   // Get static value.
-  double gator_value = Indi_Gator::iGator(_Symbol, PERIOD_CURRENT, 13, 8, 8, 5, 5, 3, MODE_SMMA, PRICE_MEDIAN, LINE_UPPER_HISTOGRAM);
+  double gator_value =
+      Indi_Gator::iGator(_Symbol, PERIOD_CURRENT, 13, 8, 8, 5, 5, 3, MODE_SMMA, PRICE_MEDIAN, LINE_UPPER_HISTOGRAM);
   // Get dynamic values.
   GatorParams params(13, 8, 8, 5, 5, 3, MODE_SMMA, PRICE_MEDIAN);
   Indi_Gator *gator = new Indi_Gator(params);
   Print("Gator upper: ", gator.GetValue(LINE_UPPER_HISTOGRAM));
-  assertTrueOrReturn(
-    gator.GetValue(LINE_UPPER_HISTOGRAM) == gator_value,
-    "Gator value does not match!",
-    false);
-  gator.SetJawPeriod(gator.GetJawPeriod()+1);
-  gator.SetJawShift(gator.GetJawShift()+1);
-  gator.SetTeethPeriod(gator.GetTeethPeriod()+1);
-  gator.SetTeethShift(gator.GetTeethShift()+1);
-  gator.SetLipsPeriod(gator.GetLipsPeriod()+1);
-  gator.SetLipsShift(gator.GetLipsShift()+1);
+  assertTrueOrReturn(gator.GetValue(LINE_UPPER_HISTOGRAM) == gator_value, "Gator value does not match!", false);
+  gator.SetJawPeriod(gator.GetJawPeriod() + 1);
+  gator.SetJawShift(gator.GetJawShift() + 1);
+  gator.SetTeethPeriod(gator.GetTeethPeriod() + 1);
+  gator.SetTeethShift(gator.GetTeethShift() + 1);
+  gator.SetLipsPeriod(gator.GetLipsPeriod() + 1);
+  gator.SetLipsShift(gator.GetLipsShift() + 1);
   // Clean up.
   delete gator;
   return true;
@@ -913,10 +834,7 @@ bool TestHeikenAshi() {
   HeikenAshiParams params(PERIOD_CURRENT);
   Indi_HeikenAshi *ha = new Indi_HeikenAshi(params);
   Print("HeikenAshi: ", ha.GetValue(HA_OPEN));
-  assertTrueOrReturn(
-    ha.GetValue(HA_OPEN) == ha_value,
-    "HeikenAshi value does not match!",
-    false);
+  assertTrueOrReturn(ha.GetValue(HA_OPEN) == ha_value, "HeikenAshi value does not match!", false);
   // Clean up.
   delete ha;
   return true;
@@ -932,13 +850,10 @@ bool TestIchimoku() {
   IchimokuParams params(9, 26, 52);
   Indi_Ichimoku *ichimoku = new Indi_Ichimoku(params);
   Print("Ichimoku: ", ichimoku.GetValue(LINE_TENKANSEN));
-  assertTrueOrReturn(
-    ichimoku.GetValue(LINE_TENKANSEN) == ichimoku_value,
-    "Ichimoku value does not match!",
-    false);
-  ichimoku.SetTenkanSen(ichimoku.GetTenkanSen()+1);
-  ichimoku.SetKijunSen(ichimoku.GetKijunSen()+1);
-  ichimoku.SetSenkouSpanB(ichimoku.GetSenkouSpanB()+1);
+  assertTrueOrReturn(ichimoku.GetValue(LINE_TENKANSEN) == ichimoku_value, "Ichimoku value does not match!", false);
+  ichimoku.SetTenkanSen(ichimoku.GetTenkanSen() + 1);
+  ichimoku.SetKijunSen(ichimoku.GetKijunSen() + 1);
+  ichimoku.SetSenkouSpanB(ichimoku.GetSenkouSpanB() + 1);
   // Clean up.
   delete ichimoku;
   return true;
@@ -954,12 +869,9 @@ bool TestMA() {
   MAParams params(13, 10, MODE_SMA, PRICE_CLOSE);
   Indi_MA *_ma = new Indi_MA(params);
   Print("MA: ", _ma.GetValue());
-  assertTrueOrReturn(
-    _ma.GetValue() == ma_value,
-    "MA value does not match!",
-    false);
-  _ma.SetPeriod(_ma.GetPeriod()+1);
-  _ma.SetShift(_ma.GetShift()+1);
+  assertTrueOrReturn(_ma.GetValue() == ma_value, "MA value does not match!", false);
+  _ma.SetPeriod(_ma.GetPeriod() + 1);
+  _ma.SetShift(_ma.GetShift() + 1);
   _ma.SetMAMethod(MODE_SMA);
   _ma.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
@@ -977,13 +889,10 @@ bool TestMACD() {
   MACDParams params(12, 26, 9, PRICE_CLOSE);
   Indi_MACD *macd = new Indi_MACD(params);
   Print("MACD: ", macd.GetValue(LINE_MAIN));
-  assertTrueOrReturn(
-    macd.GetValue(LINE_MAIN) == macd_value,
-    "MACD value does not match!",
-    false);
-  macd.SetEmaFastPeriod(macd.GetEmaFastPeriod()+1);
-  macd.SetEmaSlowPeriod(macd.GetEmaSlowPeriod()+1);
-  macd.SetSignalPeriod(macd.GetSignalPeriod()+1);
+  assertTrueOrReturn(macd.GetValue(LINE_MAIN) == macd_value, "MACD value does not match!", false);
+  macd.SetEmaFastPeriod(macd.GetEmaFastPeriod() + 1);
+  macd.SetEmaSlowPeriod(macd.GetEmaSlowPeriod() + 1);
+  macd.SetSignalPeriod(macd.GetSignalPeriod() + 1);
   macd.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
   delete macd;
@@ -1000,11 +909,8 @@ bool TestMFI() {
   MFIParams params(14);
   Indi_MFI *mfi = new Indi_MFI(params);
   Print("MFI: ", mfi.GetValue());
-  assertTrueOrReturn(
-    mfi.GetValue() == mfi_value,
-    "MFI value does not match!",
-    false);
-  mfi.SetPeriod(mfi.GetPeriod()+1);
+  assertTrueOrReturn(mfi.GetValue() == mfi_value, "MFI value does not match!", false);
+  mfi.SetPeriod(mfi.GetPeriod() + 1);
   mfi.SetAppliedVolume(VOLUME_REAL);
   // Clean up.
   delete mfi;
@@ -1021,11 +927,8 @@ bool TestMomentum() {
   MomentumParams params(12, PRICE_CLOSE);
   Indi_Momentum *mom = new Indi_Momentum(params);
   Print("Momentum: ", mom.GetValue());
-  assertTrueOrReturn(
-    mom.GetValue() == mom_value,
-    "Momentum value does not match!",
-    false);
-  mom.SetPeriod(mom.GetPeriod()+1);
+  assertTrueOrReturn(mom.GetValue() == mom_value, "Momentum value does not match!", false);
+  mom.SetPeriod(mom.GetPeriod() + 1);
   mom.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
   delete mom;
@@ -1042,10 +945,7 @@ bool TestOBV() {
   OBVParams params;
   Indi_OBV *obv = new Indi_OBV(params);
   Print("OBV: ", obv.GetValue());
-  assertTrueOrReturn(
-    obv.GetValue() == obv_value,
-    "OBV value does not match!",
-    false);
+  assertTrueOrReturn(obv.GetValue() == obv_value, "OBV value does not match!", false);
   obv.SetAppliedPrice(PRICE_MEDIAN);
   obv.SetAppliedVolume(VOLUME_REAL);
   // Clean up.
@@ -1063,13 +963,10 @@ bool TestOsMA() {
   OsMAParams params(12, 26, 9, PRICE_CLOSE);
   Indi_OsMA *osma = new Indi_OsMA(params);
   Print("OsMA: ", osma.GetValue());
-  assertTrueOrReturn(
-    osma.GetValue() == osma_value,
-    "OsMA value does not match!",
-    false);
-  osma.SetEmaFastPeriod(osma.GetEmaFastPeriod()+1);
-  osma.SetEmaSlowPeriod(osma.GetEmaSlowPeriod()+1);
-  osma.SetSignalPeriod(osma.GetSignalPeriod()+1);
+  assertTrueOrReturn(osma.GetValue() == osma_value, "OsMA value does not match!", false);
+  osma.SetEmaFastPeriod(osma.GetEmaFastPeriod() + 1);
+  osma.SetEmaSlowPeriod(osma.GetEmaSlowPeriod() + 1);
+  osma.SetSignalPeriod(osma.GetSignalPeriod() + 1);
   osma.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
   delete osma;
@@ -1086,11 +983,8 @@ bool TestRSI() {
   RSIParams params(14, PRICE_CLOSE);
   Indi_RSI *rsi = new Indi_RSI(params);
   Print("RSI: ", rsi.GetValue());
-  assertTrueOrReturn(
-    rsi.GetValue() == rsi_value,
-    "RSI value does not match!",
-    false);
-  rsi.SetPeriod(rsi.GetPeriod()+1);
+  assertTrueOrReturn(rsi.GetValue() == rsi_value, "RSI value does not match!", false);
+  rsi.SetPeriod(rsi.GetPeriod() + 1);
   rsi.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
   delete rsi;
@@ -1107,11 +1001,8 @@ bool TestRVI() {
   RVIParams params(14);
   Indi_RVI *rvi = new Indi_RVI(params);
   Print("RVI: ", rvi.GetValue(LINE_MAIN));
-  assertTrueOrReturn(
-    rvi.GetValue(LINE_MAIN) == rvi_value,
-    "RVI value does not match!",
-    false);
-  rvi.SetPeriod(rvi.GetPeriod()+1);
+  assertTrueOrReturn(rvi.GetValue(LINE_MAIN) == rvi_value, "RVI value does not match!", false);
+  rvi.SetPeriod(rvi.GetPeriod() + 1);
   // Clean up.
   delete rvi;
   return true;
@@ -1127,16 +1018,19 @@ bool TestSAR() {
   SARParams params(0.02, 0.2);
   Indi_SAR *sar = new Indi_SAR(params);
   Print("SAR: ", sar.GetValue());
-  assertTrueOrReturn(
-    sar.GetValue() == sar_value,
-    "SAR value does not match!",
-    false);
-  sar.SetStep(sar.GetStep()*2);
-  sar.SetMax(sar.GetMax()*2);
+  assertTrueOrReturn(sar.GetValue() == sar_value, "SAR value does not match!", false);
+  sar.SetStep(sar.GetStep() * 2);
+  sar.SetMax(sar.GetMax() * 2);
   // Clean up.
   delete sar;
   return true;
 }
+
+#ifdef __MQL4__
+struct StdDevTestCase {
+  int total, ma_period, ma_shift, ma_method, shift;
+};
+#endif
 
 /**
  * Test StdDev indicator.
@@ -1148,16 +1042,35 @@ bool TestStdDev() {
   StdDevParams params(13, 10, MODE_SMA, PRICE_CLOSE);
   Indi_StdDev *sd = new Indi_StdDev(params);
   Print("StdDev: ", sd.GetValue());
-  assertTrueOrReturn(
-    sd.GetValue() == sd_value,
-    "StdDev value does not match!",
-    false);
-  sd.SetMAPeriod(sd.GetMAPeriod()+1);
-  sd.SetMAShift(sd.GetMAShift()+1);
+  assertTrueOrReturn(sd.GetValue() == sd_value, "StdDev value does not match!", false);
+  sd.SetMAPeriod(sd.GetMAPeriod() + 1);
+  sd.SetMAShift(sd.GetMAShift() + 1);
   sd.SetMAMethod(MODE_SMA);
   sd.SetAppliedPrice(PRICE_MEDIAN);
   // Clean up.
   delete sd;
+
+#ifdef __MQL4__
+  // Checking iStdDevOnArray consistency between custom method and the one built-in into MT4.
+  StdDevTestCase test_cases[] = {
+      {0, 5, 0, MODE_SMA, 0},   {0, 15, 0, MODE_SMA, 0}, {0, 15, 2, MODE_SMMA, 1},
+      {0, 15, 5, MODE_SMMA, 3}, {0, 18, 3, MODE_SMA, 2},
+  };
+
+  double max_diff = 0.0001;
+
+  for (int i = 0; i < ArraySize(test_cases); ++i) {
+    double original_result = ::iStdDevOnArray(test_values, test_cases[i].total, test_cases[i].ma_period,
+                                            test_cases[i].ma_shift, test_cases[i].ma_method, test_cases[i].shift);
+    double custom_result =
+        Indi_StdDev::iStdDevOnArray(test_values, test_cases[i].total, test_cases[i].ma_period, test_cases[i].ma_shift,
+                                    test_cases[i].ma_method, test_cases[i].shift);
+
+    assertTrueOrReturnFalse(original_result > custom_result - max_diff || original_result < custom_result + max_diff,
+                            "Original result: " + DoubleToStr(original_result) +
+                                " differs from custom result: " + DoubleToStr(custom_result) + "!");
+  }
+#endif
   return true;
 }
 
@@ -1166,18 +1079,16 @@ bool TestStdDev() {
  */
 bool TestStochastic() {
   // Get static value.
-  double stoch_value = Indi_Stochastic::iStochastic(_Symbol, PERIOD_CURRENT, 5, 3, 3, MODE_SMMA, STO_LOWHIGH, LINE_MAIN);
+  double stoch_value =
+      Indi_Stochastic::iStochastic(_Symbol, PERIOD_CURRENT, 5, 3, 3, MODE_SMMA, STO_LOWHIGH, LINE_MAIN);
   // Get dynamic values.
   StochParams params(5, 3, 3, MODE_SMMA, STO_LOWHIGH);
   Indi_Stochastic *stoch = new Indi_Stochastic(params);
   Print("Stochastic: ", stoch.GetValue());
-  assertTrueOrReturn(
-    stoch.GetValue() == stoch_value,
-    "Stochastic value does not match!",
-    false);
-  stoch.SetKPeriod(stoch.GetKPeriod()+1);
-  stoch.SetDPeriod(stoch.GetDPeriod()+1);
-  stoch.SetSlowing(stoch.GetSlowing()+1);
+  assertTrueOrReturn(stoch.GetValue() == stoch_value, "Stochastic value does not match!", false);
+  stoch.SetKPeriod(stoch.GetKPeriod() + 1);
+  stoch.SetDPeriod(stoch.GetDPeriod() + 1);
+  stoch.SetSlowing(stoch.GetSlowing() + 1);
   stoch.SetMAMethod(MODE_SMA);
   stoch.SetPriceField(STO_CLOSECLOSE);
   // Clean up.
@@ -1195,11 +1106,8 @@ bool TestWPR() {
   WPRParams params(14);
   Indi_WPR *wpr = new Indi_WPR(params);
   Print("WPR: ", wpr.GetValue());
-  assertTrueOrReturn(
-    wpr.GetValue() == wpr_value,
-    "WPR value does not match!",
-    false);
-  wpr.SetPeriod(wpr.GetPeriod()+1);
+  assertTrueOrReturn(wpr.GetValue() == wpr_value, "WPR value does not match!", false);
+  wpr.SetPeriod(wpr.GetPeriod() + 1);
   // Clean up.
   delete wpr;
   return true;
@@ -1215,13 +1123,10 @@ bool TestZigZag() {
   ZigZagParams params(12, 5, 3);
   Indi_ZigZag *zz = new Indi_ZigZag(params);
   Print("ZigZag: ", zz.GetValue(ZIGZAG_BUFFER));
-  assertTrueOrReturn(
-    zz.GetValue(ZIGZAG_BUFFER) == zz_value,
-    "ZigZag value does not match!",
-    false);
-  zz.SetDepth(zz.GetDepth()+1);
-  zz.SetDeviation(zz.GetDeviation()+1);
-  zz.SetBackstep(zz.GetBackstep()+1);
+  assertTrueOrReturn(zz.GetValue(ZIGZAG_BUFFER) == zz_value, "ZigZag value does not match!", false);
+  zz.SetDepth(zz.GetDepth() + 1);
+  zz.SetDeviation(zz.GetDeviation() + 1);
+  zz.SetBackstep(zz.GetBackstep() + 1);
   // Clean up.
   delete zz;
   return true;


### PR DESCRIPTION
Added MQL4-compatible version of `iStdDevOnArray` method to be used in MQL4/MQL5 code. Provides the same results as original, MQL4's method.

- Fixes #298.