### PR TITLE
Fixes #417: Additional Serializer flags (dynamic, feature)

### DIFF
--- a/SerializerConverter.mqh
+++ b/SerializerConverter.mqh
@@ -42,10 +42,10 @@ class SerializerConverter {
   static SerializerConverter FromObject(X& _value, int serializer_flags = 0) {
     Serializer _serializer(NULL, Serialize, serializer_flags);
     _serializer.FreeRootNodeOwnership();
-    _serializer.PassObject(_value, "", _value, SERIALIZER_FLAG_ROOT_NODE);
+    _serializer.PassObject(_value, "", _value);
     SerializerConverter _converter(_serializer.GetRoot());
 #ifdef __debug__
-    Print("FromObject() result: ", _serializer.GetRoot().ToString());
+    Print("FromObject() result: ", _serializer.GetRoot() != NULL ? _serializer.GetRoot().ToString() : "NULL");
 #endif
     return _converter;
   }
@@ -54,7 +54,7 @@ class SerializerConverter {
   static SerializerConverter FromStruct(X _value, int serializer_flags = 0) {
     Serializer _serializer(NULL, Serialize, serializer_flags);
     _serializer.FreeRootNodeOwnership();
-    _serializer.PassStruct(_value, "", _value, SERIALIZER_FLAG_ROOT_NODE);
+    _serializer.PassStruct(_value, "", _value);
     SerializerConverter _converter(_serializer.GetRoot());
     return _converter;
   }

--- a/tests/SerializerTest.mq5
+++ b/tests/SerializerTest.mq5
@@ -46,11 +46,18 @@ struct SerializableSubEntry {
 
   int y;
 
-  SerializableSubEntry(int _x = 0, int _y = 0) : x(_x), y(_y) {}
+  int dynamic;
+
+  int feature;
+
+  SerializableSubEntry(int _x = 0, int _y = 0, int _dynamic = 0, int _feature = 0)
+      : x(_x), y(_y), dynamic(_dynamic), feature(_feature) {}
 
   SerializerNodeType Serialize(Serializer& s) {
     s.Pass(this, "x", x);
     s.Pass(this, "y", y);
+    s.Pass(this, "dynamic", dynamic, SERIALIZER_FIELD_FLAG_DYNAMIC);
+    s.Pass(this, "feature", feature, SERIALIZER_FIELD_FLAG_FEATURE);
     return SerializerNodeObject;
   }
 
@@ -310,6 +317,29 @@ int OnInit() {
 
   SerializerConverter::FromObject(buff_params).ToFileBinary<SerializerBinary>("buffer_struct.bin");
 
+  SerializableSubEntry dynamic_feature_entry(1, 2, 3, 4);
+
+  string subentry_none_json =
+      SerializerConverter::FromObject(dynamic_feature_entry).ToString<SerializerJson>(SERIALIZER_JSON_NO_WHITESPACES);
+  string subentry_dynamic_json = SerializerConverter::FromObject(dynamic_feature_entry, SERIALIZER_FLAG_INCLUDE_DYNAMIC)
+                                     .ToString<SerializerJson>(SERIALIZER_JSON_NO_WHITESPACES);
+  string subentry_feature_json = SerializerConverter::FromObject(dynamic_feature_entry, SERIALIZER_FLAG_INCLUDE_FEATURE)
+                                     .ToString<SerializerJson>(SERIALIZER_JSON_NO_WHITESPACES);
+  string subentry_dynamic_feature_json =
+      SerializerConverter::FromObject(dynamic_feature_entry,
+                                      SERIALIZER_FLAG_INCLUDE_DYNAMIC | SERIALIZER_FLAG_INCLUDE_FEATURE)
+          .ToString<SerializerJson>(SERIALIZER_JSON_NO_WHITESPACES);
+
+  Print("subentry_none_json = ", subentry_none_json);
+  Print("subentry_dynamic_json = ", subentry_dynamic_json);
+  Print("subentry_feature_json = ", subentry_feature_json);
+  Print("subentry_dynamic_feature_json = ", subentry_dynamic_feature_json);
+
+  assertTrueOrFail(subentry_none_json == "{\"x\":1,\"y\":2}", "Serializer flags not obeyed!");
+  assertTrueOrFail(subentry_dynamic_json == "{\"x\":1,\"y\":2,\"dynamic\":3}", "Serializer flags not obeyed!");
+  assertTrueOrFail(subentry_feature_json == "{\"x\":1,\"y\":2,\"feature\":4}", "Serializer flags not obeyed!");
+  assertTrueOrFail(subentry_dynamic_feature_json == "{\"x\":1,\"y\":2,\"dynamic\":3,\"feature\":4}",
+                   "Serializer flags not obeyed!");
 
   return INIT_SUCCEEDED;
 }


### PR DESCRIPTION
Added additional Serializer flags:
* SERIALIZER_FLAG_INCLUDE_DYNAMIC
* SERIALIZER_FLAG_INCLUDE_FEATURE

Along with additional Serializer field flags:
* SERIALIZER_FIELD_FLAG_DYNAMIC
* SERIALIZER_FIELD_FLAG_FEATURE

Usage:
```
  SerializerNodeType Serialize(Serializer& s) {
    s.Pass(this, "x", x);
    s.Pass(this, "y", y);
    s.Pass(this, "dynamic", dynamic, SERIALIZER_FIELD_FLAG_DYNAMIC);
    s.Pass(this, "feature", feature, SERIALIZER_FIELD_FLAG_FEATURE);
    return SerializerNodeObject;
  }
```

```
SerializableSubEntry dynamic_feature_entry(1, 2, 3, 4);
string subentry_dynamic_feature_json = SerializerConverter::FromObject(dynamic_feature_entry, SERIALIZER_FLAG_INCLUDE_DYNAMIC | SERIALIZER_FLAG_INCLUDE_FEATURE).ToString<SerializerJson>(SERIALIZER_JSON_NO_WHITESPACES);
```