### PR TITLE
Fixed passing of data source through Indicator class.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,6 @@ jobs:
           - Indi_Pattern.test
           - Indi_Pivot.test
           - Indi_Price.test
-          - Indi_PriceChannel.test
           - Indi_PriceFeeder.test
           - Indi_PriceVolumeTrend.test
           - Indi_RS.test
@@ -166,7 +165,6 @@ jobs:
           - Indi_WPR.test
           - Indi_WilliamsAD.test
           - Indi_ZigZag.test
-          - Indi_ZigZagColor.test
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/Chart.struct.static.h
+++ b/Chart.struct.static.h
@@ -277,10 +277,16 @@ struct ChartStatic {
    *
    * If local history is empty (not loaded), function returns 0.
    */
-  static long iVolume(string _symbol = NULL, ENUM_TIMEFRAMES _tf = PERIOD_CURRENT, uint _shift = 0) {
+  static long iVolume(string _symbol = NULL, ENUM_TIMEFRAMES _tf = PERIOD_CURRENT, int _shift = 0) {
 #ifdef __MQL4__
-    return ::iVolume(_symbol, _tf, _shift);  // Same as: Volume[_shift]
-#else                                        // __MQL5__
+    ResetLastError();
+    long _volume = ::iVolume(_symbol, _tf, _shift);  // Same as: Volume[_shift]
+    if (_LastError != ERR_NO_ERROR) {
+      _volume = EMPTY_VALUE;
+      ResetLastError();
+    }
+    return _volume;
+#else  // __MQL5__
     ARRAY(long, _arr);
     ArraySetAsSeries(_arr, true);
     return (_shift >= 0 && CopyTickVolume(_symbol, _tf, _shift, 1, _arr) > 0) ? _arr[0] : -1;

--- a/Indicator.mqh
+++ b/Indicator.mqh
@@ -77,9 +77,13 @@ class Indicator : public IndicatorBase {
   /**
    * Class constructor.
    */
-  Indicator(const TS& _iparams, IndicatorBase* _indi_src = NULL) : IndicatorBase(_iparams.GetTf(), NULL, _indi_src) {
+  Indicator(const TS& _iparams, IndicatorBase* _indi_src = NULL, bool _indi_managed = true, int _indi_mode = 0)
+      : IndicatorBase(_iparams.GetTf(), NULL) {
     iparams = _iparams;
     SetName(_iparams.name != "" ? _iparams.name : EnumToString(iparams.itype));
+    if (_indi_src != NULL) {
+      SetDataSource(_indi_src, _indi_managed, _indi_mode);
+    }
     Init();
   }
   Indicator(const TS& _iparams, ENUM_TIMEFRAMES _tf = PERIOD_CURRENT) : IndicatorBase(_tf) {

--- a/IndicatorBase.h
+++ b/IndicatorBase.h
@@ -102,23 +102,17 @@ class IndicatorBase : public Chart {
   /**
    * Class constructor.
    */
-  IndicatorBase() : indi_src(NULL) {
-    is_feeding = is_fed = false;
-  }
+  IndicatorBase() : indi_src(NULL) { is_feeding = is_fed = false; }
 
   /**
    * Class constructor.
    */
-  IndicatorBase(ChartParams& _cparams)
-    : indi_src(NULL), Chart(_cparams) {
-    is_feeding = is_fed = false;
-  }
+  IndicatorBase(ChartParams& _cparams) : indi_src(NULL), Chart(_cparams) { is_feeding = is_fed = false; }
 
   /**
    * Class constructor.
    */
-  IndicatorBase(ENUM_TIMEFRAMES _tf = PERIOD_CURRENT, string _symbol = NULL, IndicatorBase* _indi_src = NULL)
-    : indi_src(_indi_src), Chart(_tf, _symbol) {
+  IndicatorBase(ENUM_TIMEFRAMES _tf = PERIOD_CURRENT, string _symbol = NULL) : Chart(_tf, _symbol) {
     is_feeding = is_fed = false;
     indi_src = NULL;
   }
@@ -126,8 +120,7 @@ class IndicatorBase : public Chart {
   /**
    * Class constructor.
    */
-  IndicatorBase(ENUM_TIMEFRAMES_INDEX _tfi, string _symbol = NULL, IndicatorBase* _indi_src = NULL)
-    : indi_src(_indi_src), Chart(_tfi, _symbol) {
+  IndicatorBase(ENUM_TIMEFRAMES_INDEX _tfi, string _symbol = NULL) : Chart(_tfi, _symbol) {
     is_feeding = is_fed = false;
     indi_src = NULL;
   }

--- a/Indicators/Indi_AppliedPrice.mqh
+++ b/Indicators/Indi_AppliedPrice.mqh
@@ -69,6 +69,9 @@ class Indi_AppliedPrice : public Indicator<AppliedPriceParams> {
           // Future validation of indi_src will check if we set mode for source indicator
           // (e.g. for applied price of Indi_Price).
           iparams.SetDataSourceMode(GetAppliedPrice());
+        } else {
+          Print("Indi_AppliedPrice requires source indicator to be set via SetDataSource()!");
+          DebugBreak();
         }
 
         // @fixit

--- a/Indicators/Indi_Bands.mqh
+++ b/Indicators/Indi_Bands.mqh
@@ -84,7 +84,8 @@ class Indi_Bands : public Indicator<BandsParams> {
   /**
    * Class constructor.
    */
-  Indi_Bands(BandsParams &_p, IndicatorBase *_indi_src = NULL) : Indicator<BandsParams>(_p, _indi_src) {}
+  Indi_Bands(BandsParams &_p, IndicatorBase *_indi_src = NULL, bool _managed = true, int _mode = 0)
+      : Indicator<BandsParams>(_p, _indi_src, _managed, _mode) {}
   Indi_Bands(ENUM_TIMEFRAMES _tf) : Indicator(INDI_BANDS, _tf) {}
 
   /**

--- a/Indicators/Indi_ColorLine.mqh
+++ b/Indicators/Indi_ColorLine.mqh
@@ -92,7 +92,8 @@ class Indi_ColorLine : public Indicator<ColorLineParams> {
     static int ticks = 0, modified = 0;
     // Check data.
     int i, calculated = BarsCalculated(ExtMAHandle, rates_total);
-    if (calculated < rates_total && calculated < 1000) {
+    // @added History of 100 values should be enough for MA.
+    if (calculated < rates_total && calculated < 100) {
       // Not all data of ExtMAHandle is calculated.
       Print("Not all MA data calculate for ColorLine! Expected ", rates_total, ", got only ", calculated);
       return (0);

--- a/Indicators/Indi_CustomMovingAverage.mqh
+++ b/Indicators/Indi_CustomMovingAverage.mqh
@@ -37,7 +37,11 @@ struct CustomMovingAverageParams : IndicatorParams {
     SetDataValueType(TYPE_DOUBLE);
     SetDataValueRange(IDATA_RANGE_MIXED);
     SetDataSourceType(IDATA_ICUSTOM);
+#ifdef __MQL5__
     SetCustomIndicatorName("Examples\\Custom Moving Average");
+#else
+    SetCustomIndicatorName("Custom Moving Averages");
+#endif
     shift = _shift;
     smooth_method = _smooth_method;
     smooth_period = _smooth_period;

--- a/Indicators/Indi_Drawer.struct.h
+++ b/Indicators/Indi_Drawer.struct.h
@@ -64,4 +64,5 @@ SerializerNodeType DrawerParams::Serialize(Serializer &s) {
 struct DrawerGainLossData {
   double avg_gain;
   double avg_loss;
+  DrawerGainLossData() { avg_gain = avg_loss = 0.0; }
 };

--- a/Indicators/Indi_Volumes.mqh
+++ b/Indicators/Indi_Volumes.mqh
@@ -79,10 +79,6 @@ class Indi_Volumes : public Indicator<VolumesParams> {
     _cache.SetPrevCalculated(Indi_Volumes::Calculate(INDICATOR_CALCULATE_GET_PARAMS_LONG, _cache.GetBuffer<double>(0),
                                                      _cache.GetBuffer<double>(1), _av));
 
-    for (int i = 0; i < _cache.NumBuffers(); ++i) {
-      Print("(Mode #", _mode, ", Buffer #", i, " = ", _cache.GetTailValue<double>(i, _shift));
-    }
-
     return _cache.GetTailValue<double>(_mode, _shift);
   }
 
@@ -120,8 +116,6 @@ class Indi_Volumes : public Indicator<VolumesParams> {
       // Calculate indicator.
       ExtVolumesBuffer[i] = curr_volume;
       ExtColorsBuffer[i] = (curr_volume > prev_volume) ? 0.0 : 1.0;
-
-      Print("Volume: ", ExtVolumesBuffer[i].Get(), ", ", ExtColorsBuffer[i].Get());
     }
   }
 
@@ -161,7 +155,6 @@ class Indi_Volumes : public Indicator<VolumesParams> {
       for (int _mode = 0; _mode < (int)iparams.GetMaxModes(); _mode++) {
         double _v = GetValue(_mode, _shift);
         _entry.values[_mode] = _v;
-        Print("Volumes[", _mode, "] = ", _v);
       }
       _entry.SetFlag(INDI_ENTRY_FLAG_IS_VALID, !_entry.HasValue<double>(EMPTY_VALUE));
       if (_entry.IsValid()) {

--- a/Indicators/tests/Indi_AppliedPrice.test.mq5
+++ b/Indicators/tests/Indi_AppliedPrice.test.mq5
@@ -22,20 +22,23 @@
 // Includes.
 #include "../../Test.mqh"
 #include "../Indi_AppliedPrice.mqh"
+#include "../Indi_Price.mqh"
 
 /**
  * @file
  * Test functionality of Indi_AppliedPrice indicator class.
  */
 
-Indi_AppliedPrice indi(PERIOD_CURRENT);
+Indi_Price *indi_source_price = new Indi_Price();
+AppliedPriceParams indi_params();
+Ref<Indi_AppliedPrice> indi = new Indi_AppliedPrice(indi_params, indi_source_price);
 
 /**
  * Implements Init event handler.
  */
 int OnInit() {
   bool _result = true;
-  assertTrueOrFail(indi.IsValid(), "Error on IsValid!");
+  assertTrueOrFail(indi.IsSet(), "Error on IsSet!");
   // assertTrueOrFail(indi.IsValidEntry(), "Error on IsValidEntry!");
   return (_result && _LastError == ERR_NO_ERROR ? INIT_SUCCEEDED : INIT_FAILED);
 }
@@ -50,7 +53,7 @@ void OnTick() {
     // Process ticks each minute.
     if (_tick_new.time % 3600 < _tick_last.time % 3600) {
       // Print indicator values every hour.
-      Print(indi.ToString());
+      Print(indi.Ptr().ToString());
     }
   }
   _tick_last = _tick_new;

--- a/Storage/ValueStorage.volume.h
+++ b/Storage/ValueStorage.volume.h
@@ -58,5 +58,13 @@ class VolumeValueStorage : public HistoryValueStorage<long> {
   /**
    * Fetches value from a given shift. Takes into consideration as-series flag.
    */
-  virtual long Fetch(int _shift) { return iVolume(symbol, tf, RealShift(_shift)); }
+  virtual long Fetch(int _shift) {
+    ResetLastError();
+    long _volume = iVolume(symbol, tf, RealShift(_shift));
+    if (_LastError != ERR_NO_ERROR) {
+      Print("Cannot fetch iVolume! Error: ", _LastError);
+      DebugBreak();
+    }
+    return _volume;
+  }
 };

--- a/tests/DrawIndicatorTest.mq5
+++ b/tests/DrawIndicatorTest.mq5
@@ -124,7 +124,7 @@ bool InitIndicators() {
   BandsParams bands_on_price_params();
   bands_on_price_params.SetDraw(clrCadetBlue);
   // bands_on_price_params.SetDataSource(indi_price_4_bands, true, INDI_PRICE_MODE_OPEN);
-  indis.Set(INDI_BANDS_ON_PRICE, new Indi_Bands(bands_on_price_params, indi_price_4_bands));
+  indis.Set(INDI_BANDS_ON_PRICE, new Indi_Bands(bands_on_price_params, indi_price_4_bands, true));
 
   // Moving Average (MA) over Price indicator.
   PriceIndiParams price_params_4_ma();

--- a/tests/IndicatorsTest.mq5
+++ b/tests/IndicatorsTest.mq5
@@ -532,12 +532,9 @@ bool InitIndicators() {
   VIDYAParams vidya_params();
   indis.Push(new Indi_VIDYA(vidya_params));
 
-#ifdef __MQL5__
-  // @fixit Should work also in MT4!
   // Volumes.
   VolumesParams volumes_params();
   indis.Push(new Indi_Volumes(volumes_params));
-#endif
 
   // Volume Rate of Change.
   VROCParams vol_rate_of_change_params();
@@ -553,11 +550,9 @@ bool InitIndicators() {
   indis.Push(new Indi_ZigZagColor(zigzag_color_params));
 #endif
 
-#ifdef __MQL5__
   // Custom Moving Average.
   CustomMovingAverageParams cma_params();
   indis.Push(new Indi_CustomMovingAverage(cma_params));
-#endif
 
   // Math (specialized indicator).
   MathParams math_params(MATH_OP_SUB, BAND_UPPER, BAND_LOWER, 0, 0);


### PR DESCRIPTION
Note additional arguments required for Indicator constructor (`bool _managed = true, int _mode = 0`). These parameters need to be passed to `Indi_Bands` (as an example) and all other indicators.

`_managed` flag indicates that passed indicator pointer will be automatically deleted by the target indicator. Without the flag, you must delete source indicator by your own, when target indicator won't be longer used.