### PR TITLE
Fixing compilation errors due to more strict code syntax requirements in new MT5 editor

### DIFF
--- a/Account.mqh
+++ b/Account.mqh
@@ -630,14 +630,17 @@ class Account {
   }
   bool CheckCondition(ENUM_ACCOUNT_CONDITION _cond, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     return Account::CheckCondition(_cond, _args);
   }
   bool CheckCondition(ENUM_ACCOUNT_CONDITION _cond, long _arg1, long _arg2) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
-    DataParamEntry _param2 = _arg2;
+    DataParamEntry _param1;
+    _param1 = _arg1;
+    DataParamEntry _param2;
+    _param2 =_arg2;
     ArrayPushObject(_args, _param1);
     ArrayPushObject(_args, _param2);
     return Account::CheckCondition(_cond, _args);

--- a/Data.struct.h
+++ b/Data.struct.h
@@ -151,6 +151,14 @@ struct DataParamEntry : public MqlParam {
     type = TYPE_UINT;
     integer_value = _value;
   }
+  void operator=(const long _value) {
+    type = TYPE_LONG;
+    integer_value = _value;
+  }
+  void operator=(const unsigned long _value) {
+    type = TYPE_ULONG;
+    integer_value = (long)_value;
+  }
   template <typename T>
   void operator=(const T _value) {
     type = TYPE_INT;

--- a/DateTime.mqh
+++ b/DateTime.mqh
@@ -62,7 +62,7 @@ class DateTime {
    */
   DateTime() { TimeToStruct(TimeCurrent(), dt_curr); }
   DateTime(DateTimeEntry &_dt) { dt_curr = _dt; }
-  DateTime(MqlDateTime &_dt) { dt_curr = _dt; }
+  DateTime(MqlDateTime &_dt) { dt_curr = DateTimeEntry(_dt); }
   DateTime(datetime _dt) { dt_curr.Set(_dt); }
 
   /**

--- a/DateTime.struct.h
+++ b/DateTime.struct.h
@@ -301,7 +301,7 @@ struct DateTimeEntry : MqlDateTime {
   }
   // Set date and time.
   void Set(MqlDateTime& _time) {
-    THIS_REF = _time;
+    THIS_REF =  DateTimeEntry(_time);
     // @fixit Should also set day of week.
   }
   void SetDayOfMonth(int _value) {

--- a/Dict.mqh
+++ b/Dict.mqh
@@ -119,7 +119,7 @@ class Dict : public DictBase<K, V> {
   V operator[](K key) {
     if (_mode == DictModeList) return GetSlot((unsigned int)key).value;
 
-    int position;
+    unsigned int position;
     DictSlot<K, V>* slot = GetSlotByKey(_DictSlots_ref, key, position);
 
     if (!slot) return (V)NULL;
@@ -191,7 +191,7 @@ class Dict : public DictBase<K, V> {
    * Checks whether dictionary contains given value.
    */
   bool Contains(const V value) {
-    for (DictIterator<K, V> i = Begin(); i.IsValid(); ++i) {
+    for (DictIteratorBase<K, V> i = Begin(); i.IsValid(); ++i) {
       if (i.Value() == value) {
         return true;
       }

--- a/DictObject.mqh
+++ b/DictObject.mqh
@@ -42,6 +42,11 @@ class DictObjectIterator : public DictIteratorBase<K, V> {
   DictObjectIterator(DictBase<K, V>& dict, unsigned int slotIdx) : DictIteratorBase(dict, slotIdx) {}
 
   /**
+   * Constructor.
+   */
+  DictObjectIterator(DictIteratorBase<K, V>& baseIterator) : DictIteratorBase(baseIterator) {}
+
+  /**
    * Copy constructor.
    */
   DictObjectIterator(const DictObjectIterator& right) : DictIteratorBase(right) {}

--- a/DictStruct.mqh
+++ b/DictStruct.mqh
@@ -136,7 +136,7 @@ class DictStruct : public DictBase<K, V> {
   V operator[](K key) {
     DictSlot<K, V>* slot;
 
-    int position;
+    unsigned int position;
 
     if (_mode == DictModeList)
       slot = GetSlot((unsigned int)key);

--- a/EA.mqh
+++ b/EA.mqh
@@ -976,14 +976,17 @@ class EA {
   }
   bool ExecuteAction(ENUM_EA_ACTION _action, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     return EA::ExecuteAction(_action, _args);
   }
   bool ExecuteAction(ENUM_EA_ACTION _action, long _arg1, long _arg2) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
-    DataParamEntry _param2 = _arg2;
+    DataParamEntry _param1;
+    _param1 = _arg1;
+    DataParamEntry _param2;
+    _param2 = _arg2;
     ArrayPushObject(_args, _param1);
     ArrayPushObject(_args, _param2);
     return EA::ExecuteAction(_action, _args);

--- a/Indicator.mqh
+++ b/Indicator.mqh
@@ -680,7 +680,7 @@ class Indicator : public IndicatorBase {
   /**
    * Sets indicator's params.
    */
-  void SetParams(IndicatorParams& _iparams) { iparams = _iparams; }
+  void SetParams(IndicatorParams& _iparams) { (IndicatorParams)iparams = _iparams; }
 
   /**
    * Sets indicator's symbol.
@@ -763,7 +763,8 @@ class Indicator : public IndicatorBase {
   }
   bool ExecuteAction(ENUM_INDICATOR_ACTION _action, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     _args[0].integer_value = _arg1;
     return ExecuteAction(_action, _args);

--- a/IndicatorBase.h
+++ b/IndicatorBase.h
@@ -795,7 +795,8 @@ class IndicatorBase : public Chart {
   }
   bool ExecuteAction(ENUM_INDICATOR_ACTION _action, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     _args[0].integer_value = _arg1;
     return ExecuteAction(_action, _args);

--- a/Indicators/Indi_AC.mqh
+++ b/Indicators/Indi_AC.mqh
@@ -106,7 +106,8 @@ class Indi_AC : public Indicator<IndiACParams> {
    * Returns the indicator's value.
    */
   virtual IndicatorDataEntryValue GetEntryValue(int _mode = 0, int _shift = -1) {
-    IndicatorDataEntryValue _value = EMPTY_VALUE;
+    IndicatorDataEntryValue _value;
+    _value = EMPTY_VALUE;
     int _ishift = _shift >= 0 ? _shift : iparams.GetShift();
     switch (iparams.idstype) {
       case IDATA_BUILTIN:

--- a/Order.mqh
+++ b/Order.mqh
@@ -2592,7 +2592,8 @@ class Order : public SymbolInfo {
       // _reason += StringFormat(": %s", EnumToString(oparams.cond_close));
 #endif
       ARRAY(DataParamEntry, _args);
-      DataParamEntry _cond = _reason;
+      DataParamEntry _cond;
+      _cond = _reason;
       ArrayPushObject(_args, _cond);
       _result &= Order::ExecuteAction(ORDER_ACTION_CLOSE, _args);
     }

--- a/Order.struct.h
+++ b/Order.struct.h
@@ -928,7 +928,7 @@ struct OrderStatic {
  * Usage: SerializerConverter::FromObject(MqlTradeRequestProxy(_request)).ToString<SerializerJson>());
  */
 struct MqlTradeRequestProxy : MqlTradeRequest {
-  MqlTradeRequestProxy(MqlTradeRequest &r) { THIS_REF = r; }
+  MqlTradeRequestProxy(MqlTradeRequest &r) { (MqlTradeRequest)THIS_REF = r; }
 
   SerializerNodeType Serialize(Serializer &s) {
     s.PassEnum(THIS_REF, "action", action);
@@ -958,7 +958,7 @@ struct MqlTradeRequestProxy : MqlTradeRequest {
  * Usage: SerializerConverter::FromObject(MqlTradeResultProxy(_request)).ToString<SerializerJson>());
  */
 struct MqlTradeResultProxy : MqlTradeResult {
-  MqlTradeResultProxy(MqlTradeResult &r) { THIS_REF = r; }
+  MqlTradeResultProxy(MqlTradeResult &r) { (MqlTradeResult)THIS_REF = r; }
 
   SerializerNodeType Serialize(Serializer &s) {
     s.Pass(THIS_REF, "retcode", retcode);

--- a/Pattern.struct.h
+++ b/Pattern.struct.h
@@ -539,7 +539,7 @@ struct PatternCandle4 : PatternCandle {
         return
             /* Bear 0 cont. */ _c[0].open > _c[0].close &&
             /* Bear 0 is low */ _c[0].low < _c[3].low &&
-            /* Bear 0 body is large */ _c3.CheckPattern(PATTERN_3CANDLE_BODY0_GT_SUM) &&
+            /* Bear 0 body is large */ _c3 . SCOPE_MEMBER(PatternCandle, CheckPattern) (PATTERN_3CANDLE_BODY0_GT_SUM) &&
             /* Bull 1 */ _c[1].open < _c[1].close &&
             /* Bull 2 */ _c[2].open < _c[2].close &&
             /* Bear 3 */ _c[3].open > _c[3].close &&
@@ -575,7 +575,7 @@ struct PatternCandle4 : PatternCandle {
         return
             /* Bull 0 cont. */ _c[0].open < _c[0].close &&
             /* Bull 0 is high */ _c[0].high > _c[3].high &&
-            /* Bull 0 body is large */ _c3.CheckPattern(PATTERN_3CANDLE_BODY0_GT_SUM) &&
+            /* Bull 0 body is large */ _c3 . SCOPE_MEMBER(PatternCandle, CheckPattern) (PATTERN_3CANDLE_BODY0_GT_SUM) &&
             /* Bear 1 */ _c[1].open > _c[1].close &&
             /* Bear 2 */ _c[2].open > _c[2].close &&
             /* Bull 3 */ _c[3].open < _c[3].close &&

--- a/Std.h
+++ b/Std.h
@@ -222,6 +222,21 @@ const char* cstring_from(const std::string& _value) { return _value.c_str(); }
 #define STRUCT_ENUM(S, E) S::E
 #endif
 
+/**
+ * Referencing explicit struct's or class' scope.
+ *
+ * E.g., MT5 disallows method "shadowing", so when there are multiple methods
+ * with the same name then we must use 'Scope::Member', e.g.:
+ * _pattern.PatternCandle::CheckPattern(PATTERN_1CANDLE_IS_SPINNINGTOP);
+ * In MT4 we do:
+ * _pattern.CheckPattern(PATTERN_1CANDLE_IS_SPINNINGTOP);
+ */
+#ifdef __MQL4__
+#define SCOPE_MEMBER(S, M) M
+#else
+#define SCOPE_MEMBER(S, M) S::M
+#endif
+
 #ifndef __MQL__
 /**
  * @file

--- a/Storage/Objects.h
+++ b/Storage/Objects.h
@@ -49,7 +49,7 @@ class Objects {
    * Tries to retrieve pointer to object for a given key. Returns true if object did exist.
    */
   static bool TryGet(string& key, C*& out_ptr) {
-    int position;
+    unsigned int position;
     if (!GetObjects().KeyExists(key, position)) {
       out_ptr = NULL;
       return false;

--- a/Storage/ObjectsCache.h
+++ b/Storage/ObjectsCache.h
@@ -64,7 +64,7 @@ class ObjectsCache {
    * Tries to retrieve pointer to object for a given key. Returns true if object did exist.
    */
   static bool TryGet(string& key, C*& out_ptr) {
-    int position;
+    unsigned int position;
     if (!GetObjects().KeyExists(key, position)) {
       out_ptr = NULL;
       return false;

--- a/Strategy.mqh
+++ b/Strategy.mqh
@@ -722,14 +722,17 @@ class Strategy : public Object {
   }
   bool CheckCondition(ENUM_STRATEGY_CONDITION _cond, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     return Strategy::CheckCondition(_cond, _args);
   }
   bool CheckCondition(ENUM_STRATEGY_CONDITION _cond, long _arg1, long _arg2) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
-    DataParamEntry _param2 = _arg2;
+    DataParamEntry _param1;
+    _param1 = _arg1;
+    DataParamEntry _param2;
+    _param2 = _arg2;
     ArrayPushObject(_args, _param1);
     ArrayPushObject(_args, _param2);
     return Strategy::CheckCondition(_cond, _args);
@@ -818,23 +821,29 @@ class Strategy : public Object {
   }
   bool ExecuteAction(ENUM_STRATEGY_ACTION _action, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     return Strategy::ExecuteAction(_action, _args);
   }
   bool ExecuteAction(ENUM_STRATEGY_ACTION _action, long _arg1, long _arg2) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
-    DataParamEntry _param2 = _arg2;
+    DataParamEntry _param1;
+    _param1 = _arg1;
+    DataParamEntry _param2;
+    _param2 = _arg2;
     ArrayPushObject(_args, _param1);
     ArrayPushObject(_args, _param2);
     return Strategy::ExecuteAction(_action, _args);
   }
   bool ExecuteAction(ENUM_STRATEGY_ACTION _action, long _arg1, long _arg2, long _arg3) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
-    DataParamEntry _param2 = _arg2;
-    DataParamEntry _param3 = _arg3;
+    DataParamEntry _param1;
+    _param1 = _arg1;
+    DataParamEntry _param2;
+    _param2 = _arg2;
+    DataParamEntry _param3;
+    _param3 = _arg3;
     ArrayPushObject(_args, _param1);
     ArrayPushObject(_args, _param2);
     ArrayPushObject(_args, _param3);

--- a/Terminal.mqh
+++ b/Terminal.mqh
@@ -887,7 +887,8 @@ class Terminal : public Object {
   }
   bool CheckCondition(ENUM_TERMINAL_CONDITION _cond, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     return Terminal::CheckCondition(_cond, _args);
   }

--- a/Trade.mqh
+++ b/Trade.mqh
@@ -1805,7 +1805,8 @@ HistorySelect(0, TimeCurrent()); // Select history for access.
   }
   bool CheckCondition(ENUM_TRADE_CONDITION _cond, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     return Trade::CheckCondition(_cond, _args);
   }
@@ -1947,14 +1948,17 @@ HistorySelect(0, TimeCurrent()); // Select history for access.
   }
   bool ExecuteAction(ENUM_TRADE_ACTION _action, long _arg1) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
+    DataParamEntry _param1;
+    _param1 = _arg1;
     ArrayPushObject(_args, _param1);
     return Trade::ExecuteAction(_action, _args);
   }
   bool ExecuteAction(ENUM_TRADE_ACTION _action, long _arg1, long _arg2) {
     ARRAY(DataParamEntry, _args);
-    DataParamEntry _param1 = _arg1;
-    DataParamEntry _param2 = _arg2;
+    DataParamEntry _param1;
+    _param1 = _arg1;
+    DataParamEntry _param2;
+    _param2 = _arg2;
     ArrayPushObject(_args, _param1);
     ArrayPushObject(_args, _param2);
     return Trade::ExecuteAction(_action, _args);


### PR DESCRIPTION
## Summary by Sourcery

Adjust codebase to comply with stricter MQL5 compiler and editor requirements while maintaining MQL4 compatibility.

Bug Fixes:
- Fix implicit initialization of DataParamEntry and other value types by adding explicit assignments and overloads for long and unsigned long to satisfy stricter typing rules.
- Correct type usage for dictionary positions and key lookups by using unsigned int where required by the underlying APIs.
- Resolve invalid or ambiguous struct/class assignments and copies in DateTime and trade request/result proxy types to compile under the new MT5 editor.
- Ensure indicator parameter assignment and pattern-check method calls use explicit casting and scope-qualified member access where MT5 disallows shadowing or implicit conversions.
- Add missing constructor overload for DictObjectIterator to allow construction from DictIteratorBase without compilation errors.

Enhancements:
- Introduce a SCOPE_MEMBER macro to abstract MT4/MT5 differences in required scope qualification for member calls, and apply it to candle pattern checks.